### PR TITLE
Fix breaking change with upstream PxLoader

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,7 @@
 	"console-polyfill": "0.2.x",
 	"qs-polyfill": "https://gist.githubusercontent.com/chrisjlee/8960575/raw/773c8f0012522dc98f03d0f738e81bd17a95930b/querySelector.polyfill.js",
 	"nprogress": "0.2.x",
-	"PxLoader": "latest",
+	"PxLoader": "1.0.x",
 	"PxLoader-font": "https://raw.githubusercontent.com/thinkpixellab/PxLoader/fonts/PxLoaderFont.js",
 	"fontjs": "latest",
 	"krds-lazyload": "https://github.com/krds/lazyload.git#master"


### PR DESCRIPTION
Declaring dependencies with 'latest' or '*' is bad practice since it risks breaking builds retroactively. Not a good thing to have when you have ~20 projects live.

PxLoader did some refactoring in their `bower.json` with @1.1.0 causing potential breakages in downstream builds. This commit pins down to an older version that does not have these changes.
